### PR TITLE
SWAN-59 

### DIFF
--- a/android/src/com/eegeo/menu/MenuExpandableListView.java
+++ b/android/src/com/eegeo/menu/MenuExpandableListView.java
@@ -70,7 +70,7 @@ public class MenuExpandableListView extends ExpandableListView {
 		{
 			if (isGroupExpanded(i))
 			{
-				collapseGroup(i);
+				delayCollapseGroup(i);
 			}
 		}
 	}


### PR DESCRIPTION
SWAN-59 issue resolved.

There was a synchronisation issue due to that collapseGroup was called too early when the menu Adapter was redrawing its child views. So, just added delayCollapseGroup as suggested in [#22 ](https://github.com/eegeo/eegeo-example-app/pull/22)PR.
